### PR TITLE
ci: add CTRF test reporting workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,63 @@
+name: Tests
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Run tests (CTRF)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p ctrf
+
+          test_status=0
+          tmp="$(mktemp)"
+          set +e
+          go test -json ./... > "$tmp"
+          test_status=$?
+          set -e
+
+          go tool go-ctrf-json-reporter -output ctrf/tests.json < "$tmp"
+          rm -f "$tmp"
+
+          if [ "$test_status" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Publish CTRF report (job summary + sticky PR comment)
+        uses: ctrf-io/github-test-reporter@v1
+        if: always()
+        with:
+          report-path: "./ctrf/*.json"
+          summary-report: true
+          failed-report: true
+          slowest-report: true
+          flaky-rate-report: true
+          insights-report: true
+          pull-request: true
+          overwrite-comment: true
+          comment-tag: "${{ github.workflow }}-${{ github.job }}"
+          upload-artifact: true
+          fetch-previous-results: true
+          report-order: "summary-report,failed-report,flaky-rate-report,slowest-report,insights-report"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/aws/smithy-go v1.24.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
+	github.com/ctrf-io/go-ctrf-json-reporter v0.0.15 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -50,3 +51,5 @@ require (
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
 )
+
+tool github.com/ctrf-io/go-ctrf-json-reporter/cmd/go-ctrf-json-reporter

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/ctrf-io/go-ctrf-json-reporter v0.0.15 h1:dnlUISSw50Mwz1ZME4kqF4rNF+JWFqs0kQ+oaJGJShw=
+github.com/ctrf-io/go-ctrf-json-reporter v0.0.15/go.mod h1:36bVomyu0b70mpxgIQVllRXYyQFPSS+CeHZTn7zxYzQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Summary
- add a GitHub Actions Tests workflow that runs `go test -json ./...`
- convert Go test JSON to CTRF JSON (`ctrf/tests.json`) using `go tool go-ctrf-json-reporter`
- publish CTRF reports to the job summary and sticky PR comment via `ctrf-io/github-test-reporter@v1`
- pin `go-ctrf-json-reporter` in `go.mod` via a Go tool directive

## Notes
- preserves failing test status while still always publishing the report step
