### PR TITLE
ci: add CTRF reporting and golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: Lint
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.6.2
+          args: --timeout=5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,12 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: none
+  enable:
+    - govet
+    - staticcheck
+    - ineffassign
+    - unused

--- a/bench/bench_test.go
+++ b/bench/bench_test.go
@@ -15,7 +15,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"sort"
 	"testing"
 
 	"github.com/cavenine/ctxpp/internal/embed"
@@ -51,14 +50,14 @@ func generateSyntheticRepo(b *testing.B, numFiles, typesPerFile, funcsPerFile, m
 		for t := 0; t < typesPerFile; t++ {
 			typeName := fmt.Sprintf("Type%d", t)
 			code += fmt.Sprintf("// %s is a generated type for benchmarking.\ntype %s struct {\n", typeName, typeName)
-			code += fmt.Sprintf("\tName string\n\tValue int\n\tData []byte\n}\n\n")
+			code += "\tName string\n\tValue int\n\tData []byte\n}\n\n"
 
 			for m := 0; m < methodsPerFile; m++ {
 				methName := fmt.Sprintf("Method%d", m)
 				code += fmt.Sprintf("// %s performs operation %d on %s.\n", methName, m, typeName)
 				code += fmt.Sprintf("func (t *%s) %s(input string) string {\n", typeName, methName)
 				code += fmt.Sprintf("\tresult := fmt.Sprintf(\"%%s-%%d\", input, t.Value)\n")
-				code += fmt.Sprintf("\treturn strings.TrimSpace(result)\n}\n\n")
+				code += "\treturn strings.TrimSpace(result)\n}\n\n"
 			}
 		}
 
@@ -339,18 +338,4 @@ func BenchmarkDBSize_200Files(b *testing.B) {
 	if stats.SymbolsIndexed > 0 {
 		b.ReportMetric(float64(info.Size())/float64(stats.SymbolsIndexed), "bytes/symbol")
 	}
-}
-
-// percentile returns the p-th percentile of a sorted slice (0-100).
-func percentile(sorted []float64, p float64) float64 {
-	if len(sorted) == 0 {
-		return 0
-	}
-	idx := int(float64(len(sorted)-1) * p / 100)
-	return sorted[idx]
-}
-
-// sortFloat64s sorts a slice in-place.
-func sortFloat64s(s []float64) {
-	sort.Float64s(s)
 }

--- a/internal/embed/bedrock.go
+++ b/internal/embed/bedrock.go
@@ -183,8 +183,5 @@ func isBedrockNonRetryable(err error) bool {
 		return true
 	}
 	var quota *brtypes.ServiceQuotaExceededException
-	if errors.As(err, &quota) {
-		return true
-	}
-	return false
+	return errors.As(err, &quota)
 }

--- a/internal/parser/go_parser.go
+++ b/internal/parser/go_parser.go
@@ -103,17 +103,6 @@ func childByType(n *sitter.Node, typ string) *sitter.Node {
 	return nil
 }
 
-func childrenByType(n *sitter.Node, typ string) []*sitter.Node {
-	var out []*sitter.Node
-	for i := 0; i < int(n.ChildCount()); i++ {
-		c := n.Child(i)
-		if c.Type() == typ {
-			out = append(out, c)
-		}
-	}
-	return out
-}
-
 func extractPackageName(root *sitter.Node, src []byte) string {
 	clause := childByType(root, "package_clause")
 	if clause == nil {
@@ -175,11 +164,6 @@ func extractFunction(n *sitter.Node, src []byte, filePath, pkgName, receiver str
 		return nil
 	}
 	name := nodeText(nameNode, src)
-	if name == "" || name[0] < 'A' || name[0] > 'Z' {
-		// Skip unexported for now — can make configurable later.
-		// Actually include unexported too; useful for call graph.
-		// Re-include:
-	}
 
 	sig := firstLine(nodeText(n, src))
 	// Trim body brace onwards: keep only up to opening '{'.

--- a/internal/parser/http_parser.go
+++ b/internal/parser/http_parser.go
@@ -60,37 +60,38 @@ func (p *HTTPParser) Parse(filePath string, src []byte) (Result, error) {
 		}
 
 		m := httpMethodPattern.FindStringSubmatch(trimmed)
-		if m != nil {
-			method := m[1]
-			rawURL := m[2]
-
-			// Extract path from URL, stripping query params for the name.
-			path := extractPath(rawURL)
-			name := method + " " + path
-
-			startLine := i + 1 // 1-based
-
-			// Find the end of this request block (next ### or next request line or EOF).
-			endLine := findRequestEnd(lines, i+1)
-
-			doc := strings.Join(pendingComments, "\n")
-
-			res.Symbols = append(res.Symbols, types.Symbol{
-				ID:         fmt.Sprintf("%s:%s:%s", filePath, name, types.KindFunction),
-				File:       filePath,
-				Name:       name,
-				Kind:       types.KindFunction,
-				Signature:  trimmed,
-				DocComment: doc,
-				StartLine:  startLine,
-				EndLine:    endLine + 1, // 1-based
-			})
-
-			pendingComments = nil
-		} else {
+		if m == nil {
 			// Non-comment, non-method line — could be headers or body.
 			// Don't reset comments here; they belong to the next request.
+			continue
 		}
+
+		method := m[1]
+		rawURL := m[2]
+
+		// Extract path from URL, stripping query params for the name.
+		path := extractPath(rawURL)
+		name := method + " " + path
+
+		startLine := i + 1 // 1-based
+
+		// Find the end of this request block (next ### or next request line or EOF).
+		endLine := findRequestEnd(lines, i+1)
+
+		doc := strings.Join(pendingComments, "\n")
+
+		res.Symbols = append(res.Symbols, types.Symbol{
+			ID:         fmt.Sprintf("%s:%s:%s", filePath, name, types.KindFunction),
+			File:       filePath,
+			Name:       name,
+			Kind:       types.KindFunction,
+			Signature:  trimmed,
+			DocComment: doc,
+			StartLine:  startLine,
+			EndLine:    endLine + 1, // 1-based
+		})
+
+		pendingComments = nil
 	}
 
 	return res, nil


### PR DESCRIPTION
## Summary
- add CTRF test reporting workflow for pull requests
- pin the CTRF Go reporter tool in `go.mod`
- add `golangci-lint` configuration (`.golangci.yml`)
- add a dedicated lint workflow using `golangci/golangci-lint-action`
- fix baseline lint findings so lint passes with the initial rule set

## CI Workflows
- `Tests`: runs `go test -json ./...`, converts output to CTRF JSON, and publishes report summaries/comments
- `Lint`: runs golangci-lint on pull requests

## Notes
- this follows the CTRF setup pattern used in `~/source/queryops`
