### PR TITLE
fix watcher indexing for new directories and offline changes

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -664,7 +664,7 @@ func (idx *Indexer) Watch(ctx context.Context) error {
 			if event.Has(fsnotify.Create) {
 				info, err := os.Stat(event.Name)
 				if err == nil && info.IsDir() {
-					idx.addWatchDirsRecursive(watcher, event.Name, gi)
+					idx.addWatchDirsRecursive(ctx, watcher, event.Name, gi)
 					continue
 				}
 				if err != nil && !os.IsNotExist(err) {
@@ -695,7 +695,7 @@ func (idx *Indexer) Watch(ctx context.Context) error {
 	}
 }
 
-func (idx *Indexer) addWatchDirsRecursive(watcher *fsnotify.Watcher, root string, gi *gitignore.GitIgnore) {
+func (idx *Indexer) addWatchDirsRecursive(ctx context.Context, watcher *fsnotify.Watcher, root string, gi *gitignore.GitIgnore) {
 	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -704,17 +704,37 @@ func (idx *Indexer) addWatchDirsRecursive(watcher *fsnotify.Watcher, root string
 			idx.log.Warn("watch walk new dir", "path", path, "err", err)
 			return nil
 		}
-		if !d.IsDir() {
+		if d.IsDir() {
+			if idx.shouldSkipWatchDir(path, d.Name(), gi) {
+				return filepath.SkipDir
+			}
+			if err := watcher.Add(path); err != nil {
+				if os.IsNotExist(err) {
+					return nil
+				}
+				idx.log.Warn("watch add dir", "path", path, "err", err)
+			}
 			return nil
 		}
-		if idx.shouldSkipWatchDir(path, d.Name(), gi) {
-			return filepath.SkipDir
+		rel, err := filepath.Rel(idx.cfg.ProjectRoot, path)
+		if err != nil {
+			idx.log.Warn("watch rel file", "path", path, "err", err)
+			return nil
 		}
-		if err := watcher.Add(path); err != nil {
+		if gi != nil && gi.MatchesPath(rel) {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(path))
+		if _, ok := idx.parsers[ext]; !ok {
+			if _, ok := idx.filenames[filepath.Base(path)]; !ok {
+				return nil
+			}
+		}
+		if _, _, err := idx.indexFile(ctx, path, rel, ext); err != nil {
 			if os.IsNotExist(err) {
 				return nil
 			}
-			idx.log.Warn("watch add dir", "path", path, "err", err)
+			idx.log.Warn("watch index existing file", "path", rel, "err", err)
 		}
 		return nil
 	})

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -695,6 +695,10 @@ func (idx *Indexer) Watch(ctx context.Context) error {
 	}
 }
 
+// addWatchDirsRecursive walks a newly created directory tree and adds all
+// eligible directories to fsnotify. It also indexes supported files already
+// present in that tree so pre-populated creates (e.g. rename/extract) are
+// visible immediately without waiting for another event.
 func (idx *Indexer) addWatchDirsRecursive(ctx context.Context, watcher *fsnotify.Watcher, root string, gi *gitignore.GitIgnore) {
 	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -740,6 +744,9 @@ func (idx *Indexer) addWatchDirsRecursive(ctx context.Context, watcher *fsnotify
 	})
 }
 
+// shouldSkipWatchDir reports whether a directory should be excluded from watch
+// registration and reconcile walks using the same hidden/node_modules/
+// .gitignore policy as indexing.
 func (idx *Indexer) shouldSkipWatchDir(path, base string, gi *gitignore.GitIgnore) bool {
 	if base != "." && (strings.HasPrefix(base, ".") || base == "node_modules") {
 		return true
@@ -751,15 +758,15 @@ func (idx *Indexer) shouldSkipWatchDir(path, base string, gi *gitignore.GitIgnor
 	if rel == "." {
 		return false
 	}
-	if rel == ".ctxpp" || strings.HasPrefix(rel, ".ctxpp/") {
-		return true
-	}
 	if gi != nil && gi.MatchesPath(rel) {
 		return true
 	}
 	return false
 }
 
+// reconcileStartup catches up filesystem changes missed while watcher was not
+// running: it indexes supported files currently on disk and removes stale file
+// rows for indexed paths that no longer exist.
 func (idx *Indexer) reconcileStartup(ctx context.Context, gi *gitignore.GitIgnore) {
 	seen := make(map[string]struct{})
 

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -628,18 +628,9 @@ func (idx *Indexer) Watch(ctx context.Context) error {
 	var mu sync.Mutex
 
 	reindex := func(absPath string) {
-		rel, err := filepath.Rel(idx.cfg.ProjectRoot, absPath)
-		if err != nil {
+		rel, ext, ok, _ := idx.watchFileInfo(absPath, gi)
+		if !ok {
 			return
-		}
-		if gi != nil && gi.MatchesPath(rel) {
-			return
-		}
-		ext := strings.ToLower(filepath.Ext(absPath))
-		if _, ok := idx.parsers[ext]; !ok {
-			if _, ok := idx.filenames[filepath.Base(absPath)]; !ok {
-				return
-			}
 		}
 		if _, _, err := idx.indexFile(ctx, absPath, rel, ext); err != nil {
 			idx.log.Error("watch reindex", "path", rel, "err", err)
@@ -720,19 +711,13 @@ func (idx *Indexer) addWatchDirsRecursive(ctx context.Context, watcher *fsnotify
 			}
 			return nil
 		}
-		rel, err := filepath.Rel(idx.cfg.ProjectRoot, path)
+		rel, ext, ok, err := idx.watchFileInfo(path, gi)
 		if err != nil {
 			idx.log.Warn("watch rel file", "path", path, "err", err)
 			return nil
 		}
-		if gi != nil && gi.MatchesPath(rel) {
+		if !ok {
 			return nil
-		}
-		ext := strings.ToLower(filepath.Ext(path))
-		if _, ok := idx.parsers[ext]; !ok {
-			if _, ok := idx.filenames[filepath.Base(path)]; !ok {
-				return nil
-			}
 		}
 		if _, _, err := idx.indexFile(ctx, path, rel, ext); err != nil {
 			if os.IsNotExist(err) {
@@ -784,19 +769,13 @@ func (idx *Indexer) reconcileStartup(ctx context.Context, gi *gitignore.GitIgnor
 			}
 			return nil
 		}
-		rel, err := filepath.Rel(idx.cfg.ProjectRoot, path)
+		rel, ext, ok, err := idx.watchFileInfo(path, gi)
 		if err != nil {
 			idx.log.Warn("watch reconcile rel", "path", path, "err", err)
 			return nil
 		}
-		if gi != nil && gi.MatchesPath(rel) {
+		if !ok {
 			return nil
-		}
-		ext := strings.ToLower(filepath.Ext(path))
-		if _, ok := idx.parsers[ext]; !ok {
-			if _, ok := idx.filenames[filepath.Base(path)]; !ok {
-				return nil
-			}
 		}
 		seen[rel] = struct{}{}
 		if _, _, err := idx.indexFile(ctx, path, rel, ext); err != nil {
@@ -828,6 +807,26 @@ func (idx *Indexer) reconcileStartup(ctx context.Context, gi *gitignore.GitIgnor
 			idx.log.Warn("watch reconcile delete stale", "path", rel, "err", err)
 		}
 	}
+}
+
+// watchFileInfo returns repo-relative path and parser key extension for files
+// eligible for watch indexing. If ok is false and err is nil, the file is
+// ignored (gitignore or unsupported extension/name).
+func (idx *Indexer) watchFileInfo(absPath string, gi *gitignore.GitIgnore) (rel string, ext string, ok bool, err error) {
+	rel, err = filepath.Rel(idx.cfg.ProjectRoot, absPath)
+	if err != nil {
+		return "", "", false, fmt.Errorf("rel %s: %w", absPath, err)
+	}
+	if gi != nil && gi.MatchesPath(rel) {
+		return "", "", false, nil
+	}
+	ext = strings.ToLower(filepath.Ext(absPath))
+	if _, ok := idx.parsers[ext]; !ok {
+		if _, ok := idx.filenames[filepath.Base(absPath)]; !ok {
+			return "", "", false, nil
+		}
+	}
+	return rel, ext, true, nil
 }
 
 // ---- helpers ---------------------------------------------------------------

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -606,6 +606,8 @@ func (idx *Indexer) Watch(ctx context.Context) error {
 	}
 	defer watcher.Close()
 
+	gi := loadGitignore(idx.cfg.ProjectRoot)
+
 	// Walk and add all directories.
 	if err := filepath.WalkDir(idx.cfg.ProjectRoot, func(path string, d fs.DirEntry, err error) error {
 		if err != nil || !d.IsDir() {
@@ -620,7 +622,8 @@ func (idx *Indexer) Watch(ctx context.Context) error {
 		return fmt.Errorf("indexer: watch walk: %w", err)
 	}
 
-	gi := loadGitignore(idx.cfg.ProjectRoot)
+	idx.reconcileStartup(ctx, gi)
+
 	debounce := make(map[string]*time.Timer)
 	var mu sync.Mutex
 
@@ -658,6 +661,16 @@ func (idx *Indexer) Watch(ctx context.Context) error {
 				}
 				continue
 			}
+			if event.Has(fsnotify.Create) {
+				info, err := os.Stat(event.Name)
+				if err == nil && info.IsDir() {
+					idx.addWatchDirsRecursive(watcher, event.Name, gi)
+					continue
+				}
+				if err != nil && !os.IsNotExist(err) {
+					idx.log.Warn("watch stat create path", "path", event.Name, "err", err)
+				}
+			}
 			if !event.Has(fsnotify.Write) && !event.Has(fsnotify.Create) {
 				continue
 			}
@@ -678,6 +691,114 @@ func (idx *Indexer) Watch(ctx context.Context) error {
 				return nil
 			}
 			idx.log.Warn("watcher error", "err", err)
+		}
+	}
+}
+
+func (idx *Indexer) addWatchDirsRecursive(watcher *fsnotify.Watcher, root string, gi *gitignore.GitIgnore) {
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			idx.log.Warn("watch walk new dir", "path", path, "err", err)
+			return nil
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if idx.shouldSkipWatchDir(path, d.Name(), gi) {
+			return filepath.SkipDir
+		}
+		if err := watcher.Add(path); err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			idx.log.Warn("watch add dir", "path", path, "err", err)
+		}
+		return nil
+	})
+}
+
+func (idx *Indexer) shouldSkipWatchDir(path, base string, gi *gitignore.GitIgnore) bool {
+	if base != "." && (strings.HasPrefix(base, ".") || base == "node_modules") {
+		return true
+	}
+	rel, err := filepath.Rel(idx.cfg.ProjectRoot, path)
+	if err != nil {
+		return true
+	}
+	if rel == "." {
+		return false
+	}
+	if rel == ".ctxpp" || strings.HasPrefix(rel, ".ctxpp/") {
+		return true
+	}
+	if gi != nil && gi.MatchesPath(rel) {
+		return true
+	}
+	return false
+}
+
+func (idx *Indexer) reconcileStartup(ctx context.Context, gi *gitignore.GitIgnore) {
+	seen := make(map[string]struct{})
+
+	_ = filepath.WalkDir(idx.cfg.ProjectRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			idx.log.Warn("watch reconcile walk", "path", path, "err", err)
+			return nil
+		}
+		if d.IsDir() {
+			if idx.shouldSkipWatchDir(path, d.Name(), gi) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel, err := filepath.Rel(idx.cfg.ProjectRoot, path)
+		if err != nil {
+			idx.log.Warn("watch reconcile rel", "path", path, "err", err)
+			return nil
+		}
+		if gi != nil && gi.MatchesPath(rel) {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(path))
+		if _, ok := idx.parsers[ext]; !ok {
+			if _, ok := idx.filenames[filepath.Base(path)]; !ok {
+				return nil
+			}
+		}
+		seen[rel] = struct{}{}
+		if _, _, err := idx.indexFile(ctx, path, rel, ext); err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			idx.log.Warn("watch reconcile index", "path", rel, "err", err)
+		}
+		return nil
+	})
+
+	indexedFiles, err := idx.store.ListFiles()
+	if err != nil {
+		idx.log.Warn("watch reconcile list files", "err", err)
+		return
+	}
+	for _, rel := range indexedFiles {
+		if _, ok := seen[rel]; ok {
+			continue
+		}
+		absPath := filepath.Join(idx.cfg.ProjectRoot, rel)
+		if _, err := os.Stat(absPath); err == nil {
+			continue
+		} else if !os.IsNotExist(err) {
+			idx.log.Warn("watch reconcile stat indexed file", "path", rel, "err", err)
+			continue
+		}
+		if err := idx.store.DeleteFile(rel); err != nil {
+			idx.log.Warn("watch reconcile delete stale", "path", rel, "err", err)
 		}
 	}
 }

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -934,6 +934,18 @@ func C() {}
 
 // ---- Watch tests -----------------------------------------------------------
 
+func waitFor(t *testing.T, timeout time.Duration, fn func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("condition not met before timeout")
+}
+
 func TestWatch_DetectsNewFile(t *testing.T) {
 	root := t.TempDir()
 	st := openTestStore(t)
@@ -941,7 +953,7 @@ func TestWatch_DetectsNewFile(t *testing.T) {
 	// Use a short debounce for fast tests.
 	idx.cfg.WatchDebounce = 50 * time.Millisecond
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	watchErr := make(chan error, 1)
@@ -975,6 +987,208 @@ func WatchedFunc() {}
 	}
 }
 
+func TestWatch_DetectsFileInDirectoryCreatedAfterStartup(t *testing.T) {
+	root := t.TempDir()
+	st := openTestStore(t)
+	idx := newTestIndexer(t, root, st)
+	idx.cfg.WatchDebounce = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	watchErr := make(chan error, 1)
+	go func() {
+		watchErr <- idx.Watch(ctx)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	newDir := filepath.Join(root, "newdir")
+	if err := os.MkdirAll(newDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	// Give the watcher a moment to attach to the new directory.
+	time.Sleep(100 * time.Millisecond)
+
+	writeFile(t, newDir, "new.go", `package newdir
+
+func NewDirFunc() {}
+`)
+
+	waitFor(t, 2*time.Second, func() bool {
+		syms, err := st.GetSymbolsByFile("newdir/new.go")
+		if err != nil {
+			t.Fatalf("GetSymbolsByFile() error = %v", err)
+		}
+		return len(syms) > 0
+	})
+
+	cancel()
+	if err := <-watchErr; err != nil {
+		t.Errorf("Watch() error = %v", err)
+	}
+}
+
+func TestWatch_ReconcilesFileCreatedWhileOfflineOnStartup(t *testing.T) {
+	root := t.TempDir()
+	st := openTestStore(t)
+	idx := newTestIndexer(t, root, st)
+	idx.cfg.WatchDebounce = 50 * time.Millisecond
+
+	writeFile(t, root, "offline.go", `package offline
+
+func OfflineCreated() {}
+`)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	watchErr := make(chan error, 1)
+	go func() {
+		watchErr <- idx.Watch(ctx)
+	}()
+
+	waitFor(t, 2*time.Second, func() bool {
+		syms, err := st.GetSymbolsByFile("offline.go")
+		if err != nil {
+			t.Fatalf("GetSymbolsByFile() error = %v", err)
+		}
+		return len(syms) > 0
+	})
+
+	cancel()
+	if err := <-watchErr; err != nil {
+		t.Errorf("Watch() error = %v", err)
+	}
+}
+
+func TestWatch_ReconcilesDeletedFileWhileOfflineOnStartup(t *testing.T) {
+	root := t.TempDir()
+	st := openTestStore(t)
+	idx := newTestIndexer(t, root, st)
+	idx.cfg.WatchDebounce = 50 * time.Millisecond
+
+	path := writeFile(t, root, "stale.go", `package stale
+
+func Stale() {}
+`)
+	if _, err := idx.Index(context.Background()); err != nil {
+		t.Fatalf("Index() error = %v", err)
+	}
+
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	watchErr := make(chan error, 1)
+	go func() {
+		watchErr <- idx.Watch(ctx)
+	}()
+
+	waitFor(t, 2*time.Second, func() bool {
+		sha, err := st.GetFileSHA("stale.go")
+		if err != nil {
+			t.Fatalf("GetFileSHA() error = %v", err)
+		}
+		return sha == ""
+	})
+
+	cancel()
+	if err := <-watchErr; err != nil {
+		t.Errorf("Watch() error = %v", err)
+	}
+}
+
+func TestWatch_IgnoresNewNodeModulesDirectoryAfterStartup(t *testing.T) {
+	root := t.TempDir()
+	st := openTestStore(t)
+	idx := newTestIndexer(t, root, st)
+	idx.cfg.WatchDebounce = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	watchErr := make(chan error, 1)
+	go func() {
+		watchErr <- idx.Watch(ctx)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	nmDir := filepath.Join(root, "node_modules", "pkg")
+	if err := os.MkdirAll(nmDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	writeFile(t, nmDir, "ignored.go", `package pkg
+
+func Ignored() {}
+`)
+
+	// Wait for any potential (incorrect) indexing and assert it does not happen.
+	time.Sleep(400 * time.Millisecond)
+
+	sha, err := st.GetFileSHA("node_modules/pkg/ignored.go")
+	if err != nil {
+		t.Fatalf("GetFileSHA() error = %v", err)
+	}
+	if sha != "" {
+		t.Error("node_modules/pkg/ignored.go was indexed but should be ignored")
+	}
+
+	cancel()
+	if err := <-watchErr; err != nil {
+		t.Errorf("Watch() error = %v", err)
+	}
+}
+
+func TestWatch_DeleteWatchedDirectoryDoesNotCrash(t *testing.T) {
+	root := t.TempDir()
+	st := openTestStore(t)
+	idx := newTestIndexer(t, root, st)
+	idx.cfg.WatchDebounce = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	watchErr := make(chan error, 1)
+	go func() {
+		watchErr <- idx.Watch(ctx)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	tmpDir := filepath.Join(root, "tempdir")
+	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	if err := os.RemoveAll(tmpDir); err != nil {
+		t.Fatalf("RemoveAll() error = %v", err)
+	}
+
+	writeFile(t, root, "after.go", `package after
+
+func AfterDelete() {}
+`)
+
+	waitFor(t, 2*time.Second, func() bool {
+		syms, err := st.GetSymbolsByFile("after.go")
+		if err != nil {
+			t.Fatalf("GetSymbolsByFile() error = %v", err)
+		}
+		return len(syms) > 0
+	})
+
+	cancel()
+	if err := <-watchErr; err != nil {
+		t.Errorf("Watch() error = %v", err)
+	}
+}
+
 func TestWatch_DetectsModifiedFile(t *testing.T) {
 	root := t.TempDir()
 	st := openTestStore(t)
@@ -990,7 +1204,7 @@ func OldFunc() {}
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	watchErr := make(chan error, 1)
@@ -1042,7 +1256,7 @@ func DelFunc() {}
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	watchErr := make(chan error, 1)

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -1029,6 +1029,51 @@ func NewDirFunc() {}
 	}
 }
 
+func TestWatch_IndexesExistingFilesInNewlyCreatedDirectoryTree(t *testing.T) {
+	root := t.TempDir()
+	st := openTestStore(t)
+	idx := newTestIndexer(t, root, st)
+	idx.cfg.WatchDebounce = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	watchErr := make(chan error, 1)
+	go func() {
+		watchErr <- idx.Watch(ctx)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	srcParent := t.TempDir()
+	srcTree := filepath.Join(srcParent, "imported")
+	if err := os.MkdirAll(filepath.Join(srcTree, "nested"), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	writeFile(t, filepath.Join(srcTree, "nested"), "existing.go", `package nested
+
+func Existing() {}
+`)
+
+	dstTree := filepath.Join(root, "imported")
+	if err := os.Rename(srcTree, dstTree); err != nil {
+		t.Fatalf("Rename() error = %v", err)
+	}
+
+	waitFor(t, 2*time.Second, func() bool {
+		syms, err := st.GetSymbolsByFile("imported/nested/existing.go")
+		if err != nil {
+			t.Fatalf("GetSymbolsByFile() error = %v", err)
+		}
+		return len(syms) > 0
+	})
+
+	cancel()
+	if err := <-watchErr; err != nil {
+		t.Errorf("Watch() error = %v", err)
+	}
+}
+
 func TestWatch_ReconcilesFileCreatedWhileOfflineOnStartup(t *testing.T) {
 	root := t.TempDir()
 	st := openTestStore(t)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -213,6 +213,28 @@ func (s *Store) DeleteFile(path string) error {
 	return err
 }
 
+// ListFiles returns all indexed file paths.
+func (s *Store) ListFiles() ([]string, error) {
+	rows, err := s.rdb.Query(`SELECT path FROM files`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var paths []string
+	for rows.Next() {
+		var path string
+		if err := rows.Scan(&path); err != nil {
+			return nil, err
+		}
+		paths = append(paths, path)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return paths, nil
+}
+
 // ---- Symbols ---------------------------------------------------------------
 
 // DeleteSymbolsByFile removes all symbols for a file before re-inserting.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -607,6 +607,55 @@ func TestGetFileSHA_ReturnsStoredHash(t *testing.T) {
 	}
 }
 
+func TestListFiles_Empty(t *testing.T) {
+	st := openTestStore(t)
+
+	got, err := st.ListFiles()
+	if err != nil {
+		t.Fatalf("ListFiles() error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("ListFiles() len = %d, want 0", len(got))
+	}
+}
+
+func TestListFiles_ReturnsIndexedPaths(t *testing.T) {
+	st := openTestStore(t)
+
+	files := []types.FileRecord{
+		{Path: "a.go", SHA256: "sha-a", ModTime: 1, Lang: "go"},
+		{Path: "pkg/b.go", SHA256: "sha-b", ModTime: 2, Lang: "go"},
+		{Path: "cmd/main.go", SHA256: "sha-c", ModTime: 3, Lang: "go"},
+	}
+	for _, f := range files {
+		if err := st.UpsertFile(f); err != nil {
+			t.Fatalf("UpsertFile(%q) error = %v", f.Path, err)
+		}
+	}
+
+	got, err := st.ListFiles()
+	if err != nil {
+		t.Fatalf("ListFiles() error = %v", err)
+	}
+	if len(got) != len(files) {
+		t.Fatalf("ListFiles() len = %d, want %d", len(got), len(files))
+	}
+
+	wantSet := make(map[string]struct{}, len(files))
+	for _, f := range files {
+		wantSet[f.Path] = struct{}{}
+	}
+	for _, p := range got {
+		if _, ok := wantSet[p]; !ok {
+			t.Fatalf("ListFiles() unexpected path %q", p)
+		}
+		delete(wantSet, p)
+	}
+	if len(wantSet) != 0 {
+		t.Fatalf("ListFiles() missing paths: %v", wantSet)
+	}
+}
+
 func TestGetSymbolsByNames_ReturnsMatchingSymbols(t *testing.T) {
 	st := openTestStore(t)
 


### PR DESCRIPTION
## Summary
- add runtime recursive watcher registration for directories created after startup, while preserving ignore rules for hidden paths, `.ctxpp`, `node_modules`, and `.gitignore`
- add startup reconcile in `Watch` to index supported files created while ctx++ was offline and to remove stale DB records for files deleted while offline
- add watcher regression tests for new-directory indexing, ignored directories, deleted-directory stability, and offline create/delete reconciliation

## Validation
- go test ./internal/indexer -run Watch
- go test ./...