### PR TITLE
harden parser IDs and add forced reindexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ This creates `.ctxpp/index.db` in the project root. Add it to `.gitignore`:
 
 Subsequent runs only re-process changed files. Branch switches self-heal automatically via the file watcher.
 
+If parser logic changes but your source files do not, force a full reparse of supported files:
+
+```bash
+ctxpp index --path /path/to/your/project --force
+```
+
 ### 2. Add to your MCP config
 
 The examples below use Ollama with `bge-m3` (the default). If Ollama is not running, omit `CTXPP_OLLAMA_*` — ctx++ will fall back to keyword search only.
@@ -314,7 +320,7 @@ All configuration is via environment variables.
 ## CLI Reference
 
 ```
-ctxpp index [--path/-p <path>]     Index or reindex a project (default: $CTXPP_PROJECT or current directory)
+ctxpp index [--path/-p <path>] [--force]  Index or reindex a project (default: $CTXPP_PROJECT or current directory)
 ctxpp backfill [--path/-p <path>]  Re-embed symbols missing embedding vectors
 ctxpp mcp                          Start the MCP server over stdio
 ctxpp version                      Print version

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -24,9 +24,9 @@ func newIndexCmd() *cobra.Command {
 and store them in the local index database (.ctxpp/index.db).
 
 Subsequent runs are incremental: files whose content has not changed since the
-		last index pass are skipped. Use --force after parser changes to reprocess
-		unchanged files, or use 'backfill' to re-embed symbols after switching
-		embedding backends.`,
+last index pass are skipped. Use --force after parser changes to reprocess
+unchanged files, or use 'backfill' to re-embed symbols after switching
+embedding backends.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runIndex(path, force)
 			return nil

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -15,6 +15,7 @@ import (
 
 func newIndexCmd() *cobra.Command {
 	var path string
+	var force bool
 
 	cmd := &cobra.Command{
 		Use:   "index",
@@ -23,22 +24,24 @@ func newIndexCmd() *cobra.Command {
 and store them in the local index database (.ctxpp/index.db).
 
 Subsequent runs are incremental: files whose content has not changed since the
-last index pass are skipped. Use 'backfill' to re-embed symbols after switching
-embedding backends.`,
+		last index pass are skipped. Use --force after parser changes to reprocess
+		unchanged files, or use 'backfill' to re-embed symbols after switching
+		embedding backends.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runIndex(path)
+			runIndex(path, force)
 			return nil
 		},
 	}
 
 	cmd.Flags().StringVarP(&path, "path", "p", "", "Path to the project root (default: $CTXPP_PROJECT or current directory)")
+	cmd.Flags().BoolVar(&force, "force", false, "Reindex unchanged files even when file content hashes match")
 
 	return cmd
 }
 
 // runIndex is the "ctxpp index" subcommand.
 // It opens the store, detects the embedder, indexes, prints stats, and exits.
-func runIndex(path string) {
+func runIndex(path string, force bool) {
 	ctx := context.Background()
 
 	root := path
@@ -76,7 +79,7 @@ func runIndex(path string) {
 		fmt.Fprintln(os.Stderr, "         or set CTXPP_EMBED_BACKEND=bedrock for AWS Bedrock.")
 	}
 
-	idx := indexer.New(indexer.Config{ProjectRoot: root}, st, allParsers(), embedder)
+	idx := indexer.New(indexer.Config{ProjectRoot: root, Force: force}, st, allParsers(), embedder)
 	stats, err := idx.Index(ctx)
 	if err != nil {
 		slog.Error("index", "err", err)

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -46,6 +46,11 @@ type Config struct {
 	// Logger is the structured logger used by the indexer.
 	// Defaults to slog.Default() if nil.
 	Logger *slog.Logger
+
+	// Force disables unchanged-file SHA skipping for Index() runs.
+	// Useful after parser changes when file contents are unchanged but extracted
+	// symbols or edges may differ.
+	Force bool
 }
 
 func (c *Config) setDefaults() {
@@ -526,7 +531,7 @@ func (idx *Indexer) parseFile(absPath, relPath, ext string) (parsedFile, error) 
 	if err != nil {
 		return parsedFile{}, fmt.Errorf("get sha %s: %w", relPath, err)
 	}
-	if stored == sha {
+	if !idx.cfg.Force && stored == sha {
 		idx.log.Debug("skip unchanged", "path", relPath)
 		return parsedFile{relPath: relPath, skipped: true}, nil
 	}

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -522,6 +522,54 @@ func Hello() {}
 	}
 }
 
+func TestIndexer_ForceReindexesUnchangedFile(t *testing.T) {
+	root := t.TempDir()
+	st := openTestStore(t)
+	idx := New(
+		Config{ProjectRoot: root, Logger: discardLogger(), Force: true},
+		st,
+		[]parser.Parser{parser.NewGoParser()},
+		embed.NewBundledEmbedder(3),
+	)
+
+	src := `package main
+
+func Hello() {}
+`
+	writeFile(t, root, "main.go", src)
+
+	if _, err := idx.Index(t.Context()); err != nil {
+		t.Fatalf("first Index() error = %v", err)
+	}
+
+	sha1, err := st.GetFileSHA("main.go")
+	if err != nil || sha1 == "" {
+		t.Fatalf("expected SHA after first index, got %q err %v", sha1, err)
+	}
+	if err := st.UpsertFile(types.FileRecord{Path: "main.go", SHA256: sha1, ModTime: 0, Lang: "go"}); err != nil {
+		t.Fatalf("UpsertFile() error = %v", err)
+	}
+	if err := st.DeleteSymbolsByFile("main.go"); err != nil {
+		t.Fatalf("DeleteSymbolsByFile() error = %v", err)
+	}
+
+	stats, err := idx.Index(t.Context())
+	if err != nil {
+		t.Fatalf("second Index() error = %v", err)
+	}
+	if stats.FilesSkipped != 0 {
+		t.Errorf("FilesSkipped = %d, want 0 when force reindex is enabled", stats.FilesSkipped)
+	}
+
+	syms, err := st.GetSymbolsByFile("main.go")
+	if err != nil {
+		t.Fatalf("GetSymbolsByFile() error = %v", err)
+	}
+	if len(syms) == 0 {
+		t.Fatal("expected symbols after forced reindex, got none")
+	}
+}
+
 // ---- hashBytes Benchmarks --------------------------------------------------
 
 func BenchmarkHashBytes_1KB(b *testing.B) {

--- a/internal/parser/cpp_parser.go
+++ b/internal/parser/cpp_parser.go
@@ -155,6 +155,12 @@ func cppHandleDecl(n *sitter.Node, src []byte, filePath, receiver string, res *R
 			res.ImportEdges = append(res.ImportEdges, *edge)
 		}
 
+	case "alias_declaration":
+		edge := cppExtractUsing(n, src, filePath)
+		if edge != nil {
+			res.ImportEdges = append(res.ImportEdges, *edge)
+		}
+
 	case "enum_class_specifier":
 		// enum class Color { ... };
 		sym := cppEnumClassSymbol(n, src, filePath)
@@ -192,7 +198,7 @@ func cppFunctionSymbol(n *sitter.Node, src []byte, filePath, enclosingClass stri
 		sig = strings.TrimSpace(sig[:idx])
 	}
 	return &types.Symbol{
-		ID:         symbolID(filePath, name, kind),
+		ID:         symbolID(filePath, qualifiedMemberName(recv, name), kind),
 		File:       filePath,
 		Name:       name,
 		Kind:       kind,
@@ -253,7 +259,7 @@ func cppFieldDeclSymbols(n *sitter.Node, src []byte, filePath, receiver string) 
 			kind = types.KindFunction
 		}
 		syms = append(syms, types.Symbol{
-			ID:        symbolID(filePath, name, kind),
+			ID:        symbolID(filePath, qualifiedMemberName(receiver, name), kind),
 			File:      filePath,
 			Name:      name,
 			Kind:      kind,
@@ -310,6 +316,12 @@ func cppEnumClassSymbol(n *sitter.Node, src []byte, filePath string) *types.Symb
 
 // cppExtractUsing extracts a using_declaration or using_directive as an import edge.
 func cppExtractUsing(n *sitter.Node, src []byte, filePath string) *types.ImportEdge {
+	if typeNode := n.ChildByFieldName("type"); typeNode != nil {
+		return &types.ImportEdge{
+			ImporterFile: filePath,
+			ImportedPath: nodeText(typeNode, src),
+		}
+	}
 	// using std::string;  or  using namespace std;
 	for i := 0; i < int(n.ChildCount()); i++ {
 		c := n.Child(i)

--- a/internal/parser/cpp_parser_test.go
+++ b/internal/parser/cpp_parser_test.go
@@ -213,3 +213,61 @@ func TestCppParser_PopulatesSnippet(t *testing.T) {
 		t.Errorf("Snippet length %d exceeds maxSnippetBytes %d", len(sym.Snippet), maxSnippetBytes)
 	}
 }
+
+func TestCppParser_UsesReceiverQualifiedIDsForMethods(t *testing.T) {
+	src := []byte(`
+class First {
+public:
+    void render() {}
+};
+
+class Second {
+public:
+    void render() {}
+};
+`)
+
+	p := NewCppParser()
+	result, err := p.Parse("widget.hpp", src)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	wantIDs := map[string]bool{
+		"widget.hpp:First.render:method":  true,
+		"widget.hpp:Second.render:method": true,
+	}
+	for _, sym := range result.Symbols {
+		delete(wantIDs, sym.ID)
+	}
+	for id := range wantIDs {
+		t.Errorf("missing qualified symbol ID %q", id)
+	}
+}
+
+func TestCppParser_ExtractsUsingAliasTarget(t *testing.T) {
+	src := []byte(`
+using Vec = std::vector<int>;
+using namespace std;
+using std::string;
+`)
+
+	p := NewCppParser()
+	result, err := p.Parse("widget.hpp", src)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	imports := map[string]bool{}
+	for _, edge := range result.ImportEdges {
+		imports[edge.ImportedPath] = true
+	}
+	for _, want := range []string{"std::vector<int>", "std", "std::string"} {
+		if !imports[want] {
+			t.Errorf("missing import edge %q", want)
+		}
+	}
+	if imports["Vec"] {
+		t.Errorf("unexpected alias import path %q", "Vec")
+	}
+}

--- a/internal/parser/java_parser.go
+++ b/internal/parser/java_parser.go
@@ -179,8 +179,9 @@ func javaExtractMethod(n *sitter.Node, src []byte, filePath, receiver string) *t
 	if n.Type() == "constructor_declaration" {
 		kind = types.KindFunction
 	}
+	idName := qualifiedMemberName(receiver, name)
 	return &types.Symbol{
-		ID:         symbolID(filePath, name, kind),
+		ID:         symbolID(filePath, idName, kind),
 		File:       filePath,
 		Name:       name,
 		Kind:       kind,
@@ -209,13 +210,14 @@ func javaExtractFields(n *sitter.Node, src []byte, filePath, pkg string) []types
 		}
 		name := nodeText(nameNode, src)
 		syms = append(syms, types.Symbol{
-			ID:        symbolID(filePath, name, types.KindField),
+			ID:        symbolID(filePath, qualifiedMemberName(pkg, name), types.KindField),
 			File:      filePath,
 			Name:      name,
 			Kind:      types.KindField,
 			Signature: firstLine(nodeText(n, src)),
 			StartLine: int(n.StartPoint().Row) + 1,
 			EndLine:   int(n.EndPoint().Row) + 1,
+			Receiver:  pkg,
 			Package:   pkg,
 		})
 	}

--- a/internal/parser/java_parser_test.go
+++ b/internal/parser/java_parser_test.go
@@ -144,3 +144,36 @@ func TestJavaParser_RecordsLineNumbers(t *testing.T) {
 		t.Errorf("EndLine %d < StartLine %d", sym.EndLine, sym.StartLine)
 	}
 }
+
+func TestJavaParser_UsesReceiverQualifiedIDsForMembers(t *testing.T) {
+	src := []byte(`
+class First {
+    int count;
+    void render() {}
+}
+
+class Second {
+    int count;
+    void render() {}
+}
+`)
+
+	p := NewJavaParser()
+	result, err := p.Parse("Widget.java", src)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	wantIDs := map[string]bool{
+		"Widget.java:First.count:field":    true,
+		"Widget.java:Second.count:field":   true,
+		"Widget.java:First.render:method":  true,
+		"Widget.java:Second.render:method": true,
+	}
+	for _, sym := range result.Symbols {
+		delete(wantIDs, sym.ID)
+	}
+	for id := range wantIDs {
+		t.Errorf("missing qualified symbol ID %q", id)
+	}
+}

--- a/internal/parser/javascript_parser.go
+++ b/internal/parser/javascript_parser.go
@@ -191,7 +191,7 @@ func jsClassMembers(classNode *sitter.Node, src []byte, filePath, className stri
 				sig = strings.TrimSpace(sig[:idx])
 			}
 			syms = append(syms, types.Symbol{
-				ID:        symbolID(filePath, name, types.KindMethod),
+				ID:        symbolID(filePath, qualifiedMemberName(className, name), types.KindMethod),
 				File:      filePath,
 				Name:      name,
 				Kind:      types.KindMethod,

--- a/internal/parser/javascript_parser_test.go
+++ b/internal/parser/javascript_parser_test.go
@@ -171,3 +171,32 @@ func TestJavaScriptParser_RecordsLineNumbers(t *testing.T) {
 		t.Errorf("EndLine %d < StartLine %d", sym.EndLine, sym.StartLine)
 	}
 }
+
+func TestJavaScriptParser_UsesReceiverQualifiedIDsForClassMethods(t *testing.T) {
+	src := []byte(`
+class First {
+  render() {}
+}
+
+class Second {
+  render() {}
+}
+`)
+
+	p := NewJavaScriptParser()
+	result, err := p.Parse("widget.js", src)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	wantIDs := map[string]bool{
+		"widget.js:First.render:method":  true,
+		"widget.js:Second.render:method": true,
+	}
+	for _, sym := range result.Symbols {
+		delete(wantIDs, sym.ID)
+	}
+	for id := range wantIDs {
+		t.Errorf("missing qualified symbol ID %q", id)
+	}
+}

--- a/internal/parser/rust_parser.go
+++ b/internal/parser/rust_parser.go
@@ -133,8 +133,9 @@ func rustFunctionSymbol(n *sitter.Node, src []byte, filePath, receiver string) *
 	if idx := strings.Index(sig, "{"); idx >= 0 {
 		sig = strings.TrimSpace(sig[:idx])
 	}
+	idName := qualifiedMemberName(receiver, name)
 	return &types.Symbol{
-		ID:         symbolID(filePath, name, kind),
+		ID:         symbolID(filePath, idName, kind),
 		File:       filePath,
 		Name:       name,
 		Kind:       kind,
@@ -217,17 +218,38 @@ func rustImplReceiver(n *sitter.Node, src []byte) string {
 func rustExtractImport(n *sitter.Node, src []byte, filePath string) *types.ImportEdge {
 	// use_declaration contains a scoped_identifier, use_list, or identifier.
 	// We grab the text of the whole use path as the imported path.
+	if argument := n.ChildByFieldName("argument"); argument != nil {
+		path := rustImportPath(argument, src)
+		if path != "" {
+			return &types.ImportEdge{ImporterFile: filePath, ImportedPath: path}
+		}
+	}
 	for i := 0; i < int(n.ChildCount()); i++ {
 		c := n.Child(i)
 		switch c.Type() {
 		case "scoped_identifier", "identifier", "use_wildcard", "use_as_clause":
-			return &types.ImportEdge{
-				ImporterFile: filePath,
-				ImportedPath: strings.TrimSuffix(nodeText(c, src), "::*"),
+			path := rustImportPath(c, src)
+			if path != "" {
+				return &types.ImportEdge{ImporterFile: filePath, ImportedPath: path}
 			}
 		}
 	}
 	return nil
+}
+
+func rustImportPath(n *sitter.Node, src []byte) string {
+	if n == nil {
+		return ""
+	}
+	if n.Type() == "use_as_clause" {
+		if path := n.ChildByFieldName("path"); path != nil {
+			return strings.TrimSuffix(nodeText(path, src), "::*")
+		}
+	}
+	if n.Type() == "use_wildcard" {
+		return strings.TrimSuffix(nodeText(n, src), "::*")
+	}
+	return strings.TrimSuffix(nodeText(n, src), "::*")
 }
 
 // rustExtractCalls walks a function body collecting call_expression nodes.

--- a/internal/parser/rust_parser_test.go
+++ b/internal/parser/rust_parser_test.go
@@ -182,3 +182,61 @@ func TestRustParser_PopulatesSnippet(t *testing.T) {
 		t.Errorf("Snippet length %d exceeds maxSnippetBytes %d", len(sym.Snippet), maxSnippetBytes)
 	}
 }
+
+func TestRustParser_UsesReceiverQualifiedIDsForMethods(t *testing.T) {
+	src := []byte(`
+struct First;
+struct Second;
+
+impl First {
+    fn render(&self) {}
+}
+
+impl Second {
+    fn render(&self) {}
+}
+`)
+
+	p := NewRustParser()
+	result, err := p.Parse("widget.rs", src)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	wantIDs := map[string]bool{
+		"widget.rs:First.render:method":  true,
+		"widget.rs:Second.render:method": true,
+	}
+	for _, sym := range result.Symbols {
+		delete(wantIDs, sym.ID)
+	}
+	for id := range wantIDs {
+		t.Errorf("missing qualified symbol ID %q", id)
+	}
+}
+
+func TestRustParser_ExtractsAliasedUseTarget(t *testing.T) {
+	src := []byte(`
+use std::io as io;
+use crate::fmt::Display;
+`)
+
+	p := NewRustParser()
+	result, err := p.Parse("widget.rs", src)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	imports := map[string]bool{}
+	for _, edge := range result.ImportEdges {
+		imports[edge.ImportedPath] = true
+	}
+	for _, want := range []string{"std::io", "crate::fmt::Display"} {
+		if !imports[want] {
+			t.Errorf("missing import edge %q", want)
+		}
+	}
+	if imports["std::io as io"] {
+		t.Errorf("unexpected aliased import path %q", "std::io as io")
+	}
+}

--- a/internal/parser/typescript_parser_test.go
+++ b/internal/parser/typescript_parser_test.go
@@ -158,3 +158,32 @@ export default Greeting;
 		t.Errorf("Kind = %q, want %q", sym.Kind, types.KindFunction)
 	}
 }
+
+func TestTypeScriptParser_UsesReceiverQualifiedIDsForClassMethods(t *testing.T) {
+	src := []byte(`
+class First {
+  render(): void {}
+}
+
+class Second {
+  render(): void {}
+}
+`)
+
+	p := NewTypeScriptParser()
+	result, err := p.Parse("widget.ts", src)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	wantIDs := map[string]bool{
+		"widget.ts:First.render:method":  true,
+		"widget.ts:Second.render:method": true,
+	}
+	for _, sym := range result.Symbols {
+		delete(wantIDs, sym.ID)
+	}
+	for id := range wantIDs {
+		t.Errorf("missing qualified symbol ID %q", id)
+	}
+}


### PR DESCRIPTION
## Summary
- harden existing Java, JavaScript/TypeScript, Rust, and C++ parsers based on the Kotlin/C# review feedback by qualifying member symbol IDs with their receiver and tightening alias import extraction where needed
- add parser regression tests for duplicate member names across types plus aliased Rust and C++ imports
- add `ctxpp index --force` so parser changes can reprocess unchanged files without manually deleting `.ctxpp/index.db`

## Validation
- [x] go test ./...
- [x] go vet ./...
- [x] go build ./...