### PR TITLE
add OpenAI-compatible embeddings backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ All configuration is via environment variables.
 | `CTXPP_PROJECT` | `.` | Path to the project root to index |
 | `CTXPP_OLLAMA_URL` | `http://localhost:11434` | Ollama API endpoint |
 | `CTXPP_OLLAMA_MODEL` | `bge-m3` | Ollama embedding model |
-| `CTXPP_EMBED_BACKEND` | _(auto-detect)_ | Embedding backend: `ollama`, `openai`, or `bedrock` |
+| `CTXPP_EMBED_BACKEND` | _(auto-detect)_ | Embedding backend: `auto`, `ollama`, `tei`, `openai`, `bedrock`, or `bundled` |
 | `CTXPP_OPENAI_URL` | `https://api.openai.com` | OpenAI-compatible embeddings API base URL |
 | `CTXPP_OPENAI_MODEL` | _(required with `openai`)_ | OpenAI-compatible embedding model |
 | `CTXPP_OPENAI_API_KEY` | _(optional)_ | Bearer token for OpenAI-compatible providers |

--- a/README.md
+++ b/README.md
@@ -302,6 +302,52 @@ Bedrock is the right choice for CI/CD pipelines, cloud-hosted agents, or develop
 
 ---
 
+## OpenAI-Compatible Embeddings Integration
+
+ctx++ can also use any provider that exposes the OpenAI `POST /v1/embeddings` API. This includes OpenAI, OpenAI-compatible proxies, vLLM, LiteLLM, LocalAI, and Ollama's OpenAI-compatible endpoint.
+
+Set `CTXPP_EMBED_BACKEND=openai` and configure:
+
+- `CTXPP_OPENAI_URL`
+- `CTXPP_OPENAI_MODEL`
+- `CTXPP_OPENAI_DIMS`
+- `CTXPP_OPENAI_API_KEY` (optional for local unauthenticated servers)
+
+Example with OpenAI hosted embeddings:
+
+```json
+{
+  "mcpServers": {
+    "ctxpp": {
+      "command": "ctxpp",
+      "args": ["mcp"],
+      "env": {
+        "CTXPP_PROJECT": "/path/to/your/project",
+        "CTXPP_EMBED_BACKEND": "openai",
+        "CTXPP_OPENAI_URL": "https://api.openai.com",
+        "CTXPP_OPENAI_MODEL": "text-embedding-3-small",
+        "CTXPP_OPENAI_DIMS": "1536",
+        "CTXPP_OPENAI_API_KEY": "${OPENAI_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+Example with Ollama's OpenAI-compatible endpoint:
+
+```bash
+export CTXPP_EMBED_BACKEND=openai
+export CTXPP_OPENAI_URL=http://localhost:11434
+export CTXPP_OPENAI_MODEL=bge-m3
+export CTXPP_OPENAI_DIMS=1024
+ctxpp index --path /path/to/your/project
+```
+
+This backend is opt-in only. Auto-detection still prefers TEI, then Ollama, then bundled fallback.
+
+---
+
 ## Configuration
 
 All configuration is via environment variables.
@@ -311,9 +357,13 @@ All configuration is via environment variables.
 | `CTXPP_PROJECT` | `.` | Path to the project root to index |
 | `CTXPP_OLLAMA_URL` | `http://localhost:11434` | Ollama API endpoint |
 | `CTXPP_OLLAMA_MODEL` | `bge-m3` | Ollama embedding model |
-| `CTXPP_EMBED_BACKEND` | _(auto-detect)_ | Embedding backend: `ollama` or `bedrock` |
+| `CTXPP_EMBED_BACKEND` | _(auto-detect)_ | Embedding backend: `ollama`, `openai`, or `bedrock` |
+| `CTXPP_OPENAI_URL` | `https://api.openai.com` | OpenAI-compatible embeddings API base URL |
+| `CTXPP_OPENAI_MODEL` | _(required with `openai`)_ | OpenAI-compatible embedding model |
+| `CTXPP_OPENAI_API_KEY` | _(optional)_ | Bearer token for OpenAI-compatible providers |
+| `CTXPP_OPENAI_DIMS` | _(required with `openai`)_ | Embedding dimensions for the selected OpenAI-compatible model |
 | `CTXPP_WORKERS` | number of CPUs | Parallel workers for initial indexing |
-| `CTXPP_EMBED_CONCURRENCY` | `10` | Max concurrent embedding requests (Bedrock) |
+| `CTXPP_EMBED_CONCURRENCY` | `10` | Max concurrent embedding requests (mainly Bedrock) |
 
 ---
 

--- a/cmd/backfill.go
+++ b/cmd/backfill.go
@@ -78,7 +78,7 @@ func runBackfill(path string) {
 
 	embedder, active := embed.Detect(ctx)
 	if !active {
-		fmt.Fprintln(os.Stderr, "WARNING: No embedding backend detected. Set CTXPP_EMBED_BACKEND=bedrock or start Ollama before running backfill.")
+		fmt.Fprintln(os.Stderr, "WARNING: No embedding backend detected. Set CTXPP_EMBED_BACKEND=openai, set CTXPP_EMBED_BACKEND=bedrock, or start Ollama before running backfill.")
 		fmt.Fprintln(os.Stderr, "         Backfill will store zero vectors (stub embedder).")
 	} else {
 		fmt.Printf("embedder: %s (%d dims)\n", embedder.Model(), embedder.Dims())

--- a/cmd/backfill.go
+++ b/cmd/backfill.go
@@ -78,7 +78,7 @@ func runBackfill(path string) {
 
 	embedder, active := embed.Detect(ctx)
 	if !active {
-		fmt.Fprintln(os.Stderr, "WARNING: No embedding backend detected. Set CTXPP_EMBED_BACKEND=openai, set CTXPP_EMBED_BACKEND=bedrock, or start Ollama before running backfill.")
+		fmt.Fprintln(os.Stderr, "WARNING: No embedding backend detected. For OpenAI, set CTXPP_EMBED_BACKEND=openai with CTXPP_OPENAI_MODEL/CTXPP_OPENAI_DIMS (see README); or set CTXPP_EMBED_BACKEND=bedrock; or start Ollama before running backfill.")
 		fmt.Fprintln(os.Stderr, "         Backfill will store zero vectors (stub embedder).")
 	} else {
 		fmt.Printf("embedder: %s (%d dims)\n", embedder.Model(), embedder.Dims())

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -70,8 +70,8 @@ func runIndex(path string, force bool) {
 	}
 	defer st.Close()
 
-	embedder, usingOllama := embed.Detect(ctx)
-	if usingOllama {
+	embedder, usingExternal := embed.Detect(ctx)
+	if usingExternal {
 		slog.Info("embedder: active", "model", embedder.Model())
 	} else {
 		fmt.Fprintln(os.Stderr, "WARNING: No embedding backend detected -- indexing with keyword search only.")

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -76,7 +76,7 @@ func runIndex(path string, force bool) {
 	} else {
 		fmt.Fprintln(os.Stderr, "WARNING: No embedding backend detected -- indexing with keyword search only.")
 		fmt.Fprintln(os.Stderr, "         Install Ollama (https://ollama.com) and run 'ollama pull bge-m3',")
-		fmt.Fprintln(os.Stderr, "         or set CTXPP_EMBED_BACKEND=bedrock for AWS Bedrock.")
+		fmt.Fprintln(os.Stderr, "         or set CTXPP_EMBED_BACKEND=openai or CTXPP_EMBED_BACKEND=bedrock.")
 	}
 
 	idx := indexer.New(indexer.Config{ProjectRoot: root, Force: force}, st, allParsers(), embedder)

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -76,7 +76,8 @@ func runIndex(path string, force bool) {
 	} else {
 		fmt.Fprintln(os.Stderr, "WARNING: No embedding backend detected -- indexing with keyword search only.")
 		fmt.Fprintln(os.Stderr, "         Install Ollama (https://ollama.com) and run 'ollama pull bge-m3',")
-		fmt.Fprintln(os.Stderr, "         or set CTXPP_EMBED_BACKEND=openai or CTXPP_EMBED_BACKEND=bedrock.")
+		fmt.Fprintln(os.Stderr, "         or set CTXPP_EMBED_BACKEND=openai with CTXPP_OPENAI_MODEL/CTXPP_OPENAI_DIMS,")
+		fmt.Fprintln(os.Stderr, "         or set CTXPP_EMBED_BACKEND=bedrock. See README for details.")
 	}
 
 	idx := indexer.New(indexer.Config{ProjectRoot: root, Force: force}, st, allParsers(), embedder)

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -82,7 +82,7 @@ func runMCP() {
 	if usingOllama {
 		slog.Info("embedder: active", "model", baseEmbedder.Model())
 	} else {
-		slog.Warn("No embedding backend detected -- semantic search disabled. Install Ollama (https://ollama.com) and run 'ollama pull bge-m3', or set CTXPP_EMBED_BACKEND=openai or CTXPP_EMBED_BACKEND=bedrock.")
+		slog.Warn("No embedding backend detected -- semantic search disabled. Install Ollama (https://ollama.com) and run 'ollama pull bge-m3', or configure OpenAI/Bedrock: set CTXPP_EMBED_BACKEND=openai with CTXPP_OPENAI_MODEL and CTXPP_OPENAI_DIMS, or set CTXPP_EMBED_BACKEND=bedrock. See README for details.")
 	}
 
 	parsers := allParsers()

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -77,9 +77,9 @@ func runMCP() {
 	// pollute or evict the query-time cache.
 	// queryEmbedder wraps indexEmbedder with CachingEmbedder so repeated
 	// identical search queries avoid hitting the backend on every call.
-	baseEmbedder, usingOllama := embed.Detect(ctx)
+	baseEmbedder, usingExternal := embed.Detect(ctx)
 	queryEmbedder := embed.NewCachingEmbedder(baseEmbedder)
-	if usingOllama {
+	if usingExternal {
 		slog.Info("embedder: active", "model", baseEmbedder.Model())
 	} else {
 		slog.Warn("No embedding backend detected -- semantic search disabled. Install Ollama (https://ollama.com) and run 'ollama pull bge-m3', or configure OpenAI/Bedrock: set CTXPP_EMBED_BACKEND=openai with CTXPP_OPENAI_MODEL and CTXPP_OPENAI_DIMS, or set CTXPP_EMBED_BACKEND=bedrock. See README for details.")

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -82,7 +82,7 @@ func runMCP() {
 	if usingOllama {
 		slog.Info("embedder: active", "model", baseEmbedder.Model())
 	} else {
-		slog.Warn("No embedding backend detected -- semantic search disabled. Install Ollama (https://ollama.com) and run 'ollama pull bge-m3', or set CTXPP_EMBED_BACKEND=bedrock for AWS Bedrock.")
+		slog.Warn("No embedding backend detected -- semantic search disabled. Install Ollama (https://ollama.com) and run 'ollama pull bge-m3', or set CTXPP_EMBED_BACKEND=openai or CTXPP_EMBED_BACKEND=bedrock.")
 	}
 
 	parsers := allParsers()

--- a/docs/OPENAI-EMBEDDINGS-BACKEND-PLAN.md
+++ b/docs/OPENAI-EMBEDDINGS-BACKEND-PLAN.md
@@ -1,0 +1,232 @@
+# OpenAI-Compatible Embeddings Backend Plan
+
+This document scopes and sequences issue `#4` (`feat: OpenAI-compatible embeddings backend`).
+
+The goal is to add a new embedding backend that targets the OpenAI `POST /v1/embeddings` API so ctx++ can work with OpenAI, Azure OpenAI-style proxies, vLLM, LiteLLM, LocalAI, and any other OpenAI-compatible server.
+
+## Goals
+
+- Add an opt-in `openai` embedding backend behind `CTXPP_EMBED_BACKEND=openai`.
+- Support both single-text and batched embedding calls.
+- Keep the existing auto-detect flow unchanged for Ollama, TEI, Bedrock, and bundled fallback.
+- Preserve ctx++'s current portability and retry behavior.
+- Document configuration clearly enough that users can switch providers without code changes.
+
+## Non-Goals
+
+- Replacing the native Ollama backend.
+- Changing default backend detection order.
+- Adding provider-specific auth flows beyond bearer-token support.
+- Solving every provider-specific URL shape in v1 of this backend.
+
+---
+
+## User-Facing Design
+
+### Activation
+
+- Backend name: `openai`
+- Opt-in only via `CTXPP_EMBED_BACKEND=openai`
+
+### Environment Variables
+
+- `CTXPP_OPENAI_URL`
+  - Default: `https://api.openai.com`
+  - Base URL for any OpenAI-compatible server
+- `CTXPP_OPENAI_MODEL`
+  - Required when backend is forced
+  - Example: `text-embedding-3-small`
+- `CTXPP_OPENAI_API_KEY`
+  - Optional
+  - If set, send `Authorization: Bearer <token>`
+  - If unset, send no auth header to support local unauthenticated servers
+- `CTXPP_OPENAI_DIMS`
+  - Required when backend is forced
+  - Used for schema compatibility and response validation
+
+### Request/Response Contract
+
+Request:
+
+```json
+{
+  "model": "text-embedding-3-small",
+  "input": ["text1", "text2"]
+}
+```
+
+Response:
+
+```json
+{
+  "data": [
+    {"index": 0, "embedding": [0.1, 0.2]},
+    {"index": 1, "embedding": [0.3, 0.4]}
+  ]
+}
+```
+
+### Compatibility Notes
+
+- Native OpenAI-compatible endpoints should work directly.
+- Ollama can be used through this path when exposed via `/v1/embeddings`.
+- Azure-specific deployment paths are not a v1 requirement; treat them as follow-up work if the generic base URL approach is insufficient.
+
+---
+
+## Implementation Plan
+
+### 1) Add a new embedder
+
+Add `internal/embed/openai.go` with:
+
+- `type OpenAIEmbedder struct`
+- `NewOpenAIEmbedder(baseURL, model, apiKey string, dims int) *OpenAIEmbedder`
+- `Model() string`
+- `Dims() int`
+- `Embed(ctx, text)`
+- `EmbedBatch(ctx, texts)`
+- `Ping(ctx)`
+
+Implementation should mirror current backend patterns:
+
+- HTTP client setup should follow the tuned transport style already used by `OllamaEmbedder` and `TEIEmbedder`.
+- Batch support should be first-class, not an afterthought, because the indexer benefits heavily from `BatchEmbedder`.
+- Errors should always be wrapped with context using `fmt.Errorf("context: %w", err)`.
+
+### 2) Define request/response types
+
+Add internal JSON structs for:
+
+- request body with `model` and `input`
+- response body with `data[].index` and `data[].embedding`
+- optional error body for clearer HTTP failures when providers return JSON errors
+
+The implementation should:
+
+- preserve response ordering by `index`
+- reject empty `data`
+- reject embeddings whose length does not match configured dims
+- reject batch responses whose count does not match request size
+
+### 3) Integrate with backend detection
+
+Update `internal/embed/embed.go`:
+
+- extend the env var documentation block to include `openai`
+- read `CTXPP_OPENAI_URL`, `CTXPP_OPENAI_MODEL`, `CTXPP_OPENAI_API_KEY`, `CTXPP_OPENAI_DIMS`
+- add `case "openai": ...` in `Detect`
+
+Recommended behavior:
+
+- if forced and required vars are missing or invalid, return bundled fallback with a warning-compatible failure path rather than panic
+- wrap the embedder with `NewRetryingEmbedder(...)`
+- keep `usingExternal=true` only when the backend is actually reachable/usable
+
+### 4) Ping behavior
+
+`Ping` should perform a tiny embedding request instead of calling a provider-specific models endpoint.
+
+Reasoning:
+
+- the actual embed path is what ctx++ depends on
+- OpenAI-compatible servers vary in what auxiliary endpoints they implement
+- a minimal real request is the best compatibility check
+
+### 5) Update user messaging
+
+Update command warnings and setup text in:
+
+- `cmd/index.go`
+- `cmd/mcp.go`
+- `cmd/backfill.go`
+
+These messages should mention OpenAI-compatible backends as a supported alternative, not only Ollama and Bedrock.
+
+### 6) Update docs
+
+Update `README.md` with:
+
+- backend overview including `openai`
+- env var table or examples
+- one hosted example
+- one local OpenAI-compatible example
+
+Suggested examples:
+
+- OpenAI hosted embeddings
+- Ollama using `/v1/embeddings`
+- a generic self-hosted proxy example
+
+---
+
+## Testing Plan
+
+Add httptest-based unit coverage similar to existing embedder tests.
+
+### New tests
+
+Add tests for:
+
+- single embed success
+- batch embed success
+- auth header present when API key is set
+- auth header absent when API key is unset
+- non-200 response handling
+- invalid JSON response
+- empty `data` response
+- dims mismatch
+- response count mismatch for batch requests
+- `Detect()` with `CTXPP_EMBED_BACKEND=openai`
+- invalid `CTXPP_OPENAI_DIMS` handling
+
+### Validation commands
+
+- `go test ./...`
+- `go vet ./...`
+
+If the change is clean and time permits:
+
+- `go test -race ./...`
+
+---
+
+## Open Questions
+
+### Should dims be required?
+
+Recommendation: yes for v1.
+
+- ctx++ stores vectors with known dimensions
+- explicit dims avoid silent schema drift
+- probing dims at startup adds provider-specific behavior and ambiguity
+
+### Should this backend auto-detect?
+
+Recommendation: no for now.
+
+- auto-detecting arbitrary OpenAI-compatible providers is unreliable
+- opt-in keeps current local-first behavior intact
+
+### Should Azure OpenAI be handled now?
+
+Recommendation: not unless it falls out naturally from the base URL design.
+
+- Azure's path and query conventions differ enough that it may deserve a dedicated follow-up backend or URL-template support
+
+---
+
+## Suggested Delivery Order
+
+1. Implement `OpenAIEmbedder` with single and batch support.
+2. Wire `openai` into `Detect` and env parsing.
+3. Add focused unit tests.
+4. Update CLI warnings and README examples.
+5. Validate with `go test ./...` and `go vet ./...`.
+
+## Success Criteria
+
+- A user can set `CTXPP_EMBED_BACKEND=openai` and successfully index/search using an OpenAI-compatible embeddings API.
+- Batch embedding works through the same backend.
+- Misconfiguration fails clearly.
+- Existing Ollama, TEI, Bedrock, and bundled behavior remains unchanged.

--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -386,7 +386,7 @@ func (r *RetryingEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]
 //
 // Environment variables:
 //
-//	CTXPP_EMBED_BACKEND    "auto" (default), "ollama", "tei", "bedrock", or "bundled"
+//	CTXPP_EMBED_BACKEND    "auto" (default), "ollama", "tei", "bedrock", "openai", or "bundled"
 //	CTXPP_OLLAMA_URL       Ollama base URL (default http://localhost:11434)
 //	CTXPP_OLLAMA_MODEL     Ollama model name (default all-minilm)
 //	CTXPP_OLLAMA_SOCKET    Unix domain socket path (optional; bypasses TCP)
@@ -396,6 +396,10 @@ func (r *RetryingEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]
 //	CTXPP_BEDROCK_REGION   AWS region (default us-east-1)
 //	CTXPP_BEDROCK_MODEL    Bedrock model ID (default amazon.titan-embed-text-v2:0)
 //	CTXPP_BEDROCK_DIMS     Bedrock embedding dimensions: 256, 512, or 1024 (default 1024)
+//	CTXPP_OPENAI_URL       OpenAI-compatible base URL (default https://api.openai.com)
+//	CTXPP_OPENAI_MODEL     OpenAI-compatible embedding model name (required when backend=openai)
+//	CTXPP_OPENAI_API_KEY   Optional bearer token for OpenAI-compatible APIs
+//	CTXPP_OPENAI_DIMS      Embedding dimensions for the selected model (required when backend=openai)
 func Detect(ctx context.Context) (Embedder, bool) {
 	backend := os.Getenv("CTXPP_EMBED_BACKEND")
 	ollamaURL := os.Getenv("CTXPP_OLLAMA_URL")
@@ -406,6 +410,10 @@ func Detect(ctx context.Context) (Embedder, bool) {
 	bedrockRegion := os.Getenv("CTXPP_BEDROCK_REGION")
 	bedrockModel := os.Getenv("CTXPP_BEDROCK_MODEL")
 	bedrockDimsStr := os.Getenv("CTXPP_BEDROCK_DIMS")
+	openAIURL := os.Getenv("CTXPP_OPENAI_URL")
+	openAIModel := os.Getenv("CTXPP_OPENAI_MODEL")
+	openAIAPIKey := os.Getenv("CTXPP_OPENAI_API_KEY")
+	openAIDimsStr := os.Getenv("CTXPP_OPENAI_DIMS")
 
 	retryCfg := RetryConfig{} // uses defaults: 3 retries, 100ms base backoff
 
@@ -439,6 +447,13 @@ func Detect(ctx context.Context) (Embedder, bool) {
 			BaseBackoff: 500 * time.Millisecond,
 		}
 		return NewRetryingEmbedder(e, bedrockRetryCfg), true
+	case "openai":
+		openAIDims, err := strconv.Atoi(openAIDimsStr)
+		if err != nil || openAIDims <= 0 || openAIModel == "" {
+			return NewBundledEmbedder(ollamaDims), false
+		}
+		e := NewOpenAIEmbedder(openAIURL, openAIModel, openAIAPIKey, openAIDims)
+		return NewRetryingEmbedder(e, retryCfg), true
 	default: // "auto" or empty: probe TEI first, then Ollama, then bundled
 		tei := NewTEIEmbedder(teiURL, teiModel, 0)
 		if err := tei.Ping(ctx); err == nil {

--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -388,7 +388,7 @@ func (r *RetryingEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]
 //
 //	CTXPP_EMBED_BACKEND    "auto" (default), "ollama", "tei", "bedrock", "openai", or "bundled"
 //	CTXPP_OLLAMA_URL       Ollama base URL (default http://localhost:11434)
-//	CTXPP_OLLAMA_MODEL     Ollama model name (default all-minilm)
+//	CTXPP_OLLAMA_MODEL     Ollama model name (default bge-m3)
 //	CTXPP_OLLAMA_SOCKET    Unix domain socket path (optional; bypasses TCP)
 //	CTXPP_TEI_URL          TEI base URL (default http://localhost:8080)
 //	CTXPP_TEI_MODEL        TEI model identifier (default sentence-transformers/all-MiniLM-L6-v2)

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -570,6 +571,121 @@ func TestOpenAIEmbedder_EmbedBatch_ReordersByIndex(t *testing.T) {
 	}
 	if got := vecs[1][0]; got != 1 {
 		t.Errorf("vecs[1][0] = %v, want 1", got)
+	}
+}
+
+func TestOpenAIEmbedder_Embed_InvalidJSON(t *testing.T) {
+	_, e := newTestOpenAIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("not json"))
+	})
+
+	_, err := e.Embed(context.Background(), "hello world")
+	if err == nil {
+		t.Fatal("Embed() error = nil, want decode error")
+	}
+}
+
+func TestOpenAIEmbedder_Embed_EmptyData(t *testing.T) {
+	_, e := newTestOpenAIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(openAIEmbedResponse{Data: []openAIEmbedData{}})
+	})
+
+	_, err := e.Embed(context.Background(), "hello world")
+	if err == nil {
+		t.Fatal("Embed() error = nil, want empty response error")
+	}
+}
+
+func TestOpenAIEmbedder_EmbedBatch_CountMismatch(t *testing.T) {
+	_, e := newTestOpenAIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(openAIEmbedResponse{
+			Data: []openAIEmbedData{{Index: 0, Embedding: []float32{0.1, 0.2, 0.3}}},
+		})
+	})
+
+	_, err := e.EmbedBatch(context.Background(), []string{"first", "second"})
+	if err == nil {
+		t.Fatal("EmbedBatch() error = nil, want count mismatch error")
+	}
+}
+
+func TestOpenAIEmbedder_Embed_DimsMismatch(t *testing.T) {
+	_, e := newTestOpenAIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(openAIEmbedResponse{
+			Data: []openAIEmbedData{{Index: 0, Embedding: []float32{0.1, 0.2}}},
+		})
+	})
+
+	_, err := e.Embed(context.Background(), "hello world")
+	if err == nil {
+		t.Fatal("Embed() error = nil, want dims mismatch error")
+	}
+}
+
+func TestOpenAIEmbedder_EmbedBatch_DuplicateIndex(t *testing.T) {
+	_, e := newTestOpenAIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(openAIEmbedResponse{
+			Data: []openAIEmbedData{
+				{Index: 0, Embedding: []float32{0.1, 0.2, 0.3}},
+				{Index: 0, Embedding: []float32{0.4, 0.5, 0.6}},
+			},
+		})
+	})
+
+	_, err := e.EmbedBatch(context.Background(), []string{"first", "second"})
+	if err == nil {
+		t.Fatal("EmbedBatch() error = nil, want duplicate index error")
+	}
+}
+
+func TestOpenAIEmbedder_EmbedBatch_MissingIndex(t *testing.T) {
+	_, e := newTestOpenAIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(openAIEmbedResponse{
+			Data: []openAIEmbedData{
+				{Index: 0, Embedding: []float32{0.1, 0.2, 0.3}},
+				{Index: 2, Embedding: []float32{0.4, 0.5, 0.6}},
+			},
+		})
+	})
+
+	_, err := e.EmbedBatch(context.Background(), []string{"first", "second"})
+	if err == nil {
+		t.Fatal("EmbedBatch() error = nil, want missing index error")
+	}
+}
+
+func TestOpenAIEmbedder_Embed_ServerErrorIncludesAPIMessage(t *testing.T) {
+	_, e := newTestOpenAIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(openAIErrorResponse{Error: &struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+			Code    any    `json:"code"`
+		}{Message: "rate limit"}})
+	})
+
+	_, err := e.Embed(context.Background(), "hello world")
+	if err == nil {
+		t.Fatal("Embed() error = nil, want HTTP error")
+	}
+	if got := err.Error(); !strings.Contains(got, "rate limit") {
+		t.Fatalf("Embed() error = %q, want API message", got)
+	}
+}
+
+func TestOpenAIEmbedder_Embed_InvalidConfiguration(t *testing.T) {
+	e := NewOpenAIEmbedder("https://example.com", "", "", 0)
+
+	_, err := e.Embed(context.Background(), "hello world")
+	if err == nil {
+		t.Fatal("Embed() error = nil, want configuration error")
 	}
 }
 

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -662,8 +662,8 @@ func TestOpenAIEmbedder_EmbedBatch_MissingIndex(t *testing.T) {
 
 func TestOpenAIEmbedder_Embed_ServerErrorIncludesAPIMessage(t *testing.T) {
 	_, e := newTestOpenAIServer(t, func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusTooManyRequests)
 		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
 		json.NewEncoder(w).Encode(openAIErrorResponse{Error: &struct {
 			Message string `json:"message"`
 			Type    string `json:"type"`
@@ -677,6 +677,27 @@ func TestOpenAIEmbedder_Embed_ServerErrorIncludesAPIMessage(t *testing.T) {
 	}
 	if got := err.Error(); !strings.Contains(got, "rate limit") {
 		t.Fatalf("Embed() error = %q, want API message", got)
+	}
+}
+
+func TestOpenAIEmbedder_Embed_ClientErrorIsNonRetryable(t *testing.T) {
+	_, e := newTestOpenAIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(openAIErrorResponse{Error: &struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+			Code    any    `json:"code"`
+		}{Message: "bad key"}})
+	})
+
+	_, err := e.Embed(context.Background(), "hello world")
+	if err == nil {
+		t.Fatal("Embed() error = nil, want HTTP error")
+	}
+	var nonRetryable *NonRetryableError
+	if !errors.As(err, &nonRetryable) {
+		t.Fatalf("Embed() error = %T, want *NonRetryableError", err)
 	}
 }
 

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -457,6 +457,136 @@ func TestOllamaEmbedder_Ping_Failure(t *testing.T) {
 	}
 }
 
+func newTestOpenAIServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *OpenAIEmbedder) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	e := NewOpenAIEmbedder(srv.URL, "test-model", "test-key", 3)
+	return srv, e
+}
+
+func TestOpenAIEmbedder_Embed_Success(t *testing.T) {
+	_, e := newTestOpenAIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/embeddings" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want %q", got, "Bearer test-key")
+		}
+
+		var req openAIEmbedRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if req.Model != "test-model" {
+			t.Errorf("request model = %q, want %q", req.Model, "test-model")
+		}
+		if len(req.Input) != 1 || req.Input[0] != "hello world" {
+			t.Errorf("request input = %v, want [hello world]", req.Input)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(openAIEmbedResponse{
+			Data: []openAIEmbedData{{Index: 0, Embedding: []float32{0.1, 0.2, 0.3}}},
+		})
+	})
+
+	vec, err := e.Embed(context.Background(), "hello world")
+	if err != nil {
+		t.Fatalf("Embed() error = %v", err)
+	}
+	if len(vec) != 3 || vec[0] != 0.1 || vec[1] != 0.2 || vec[2] != 0.3 {
+		t.Errorf("Embed() = %v, want [0.1 0.2 0.3]", vec)
+	}
+}
+
+func TestOpenAIEmbedder_Embed_OmitsAuthorizationWhenAPIKeyUnset(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Errorf("Authorization = %q, want empty header", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(openAIEmbedResponse{
+			Data: []openAIEmbedData{{Index: 0, Embedding: []float32{0.1, 0.2, 0.3}}},
+		})
+	}))
+	defer srv.Close()
+
+	e := NewOpenAIEmbedder(srv.URL, "test-model", "", 3)
+	if _, err := e.Embed(context.Background(), "hello world"); err != nil {
+		t.Fatalf("Embed() error = %v", err)
+	}
+}
+
+func TestDetect_RespectsEmbedBackendOpenAI(t *testing.T) {
+	t.Setenv("CTXPP_EMBED_BACKEND", "openai")
+	t.Setenv("CTXPP_OPENAI_URL", "https://example.com")
+	t.Setenv("CTXPP_OPENAI_MODEL", "text-embedding-3-small")
+	t.Setenv("CTXPP_OPENAI_DIMS", "1536")
+
+	e, usingExternal := Detect(context.Background())
+	if !usingExternal {
+		t.Fatal("Detect() usingExternal = false, want true")
+	}
+	re, ok := e.(*RetryingEmbedder)
+	if !ok {
+		t.Fatalf("Detect() returned %T, want *RetryingEmbedder", e)
+	}
+	oe, ok := re.inner.(*OpenAIEmbedder)
+	if !ok {
+		t.Fatalf("inner = %T, want *OpenAIEmbedder", re.inner)
+	}
+	if oe.Model() != "text-embedding-3-small" {
+		t.Errorf("Model() = %q, want %q", oe.Model(), "text-embedding-3-small")
+	}
+	if oe.Dims() != 1536 {
+		t.Errorf("Dims() = %d, want 1536", oe.Dims())
+	}
+}
+
+func TestOpenAIEmbedder_EmbedBatch_ReordersByIndex(t *testing.T) {
+	_, e := newTestOpenAIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(openAIEmbedResponse{
+			Data: []openAIEmbedData{
+				{Index: 1, Embedding: []float32{1, 1, 1}},
+				{Index: 0, Embedding: []float32{0, 0, 0}},
+			},
+		})
+	})
+
+	vecs, err := e.EmbedBatch(context.Background(), []string{"first", "second"})
+	if err != nil {
+		t.Fatalf("EmbedBatch() error = %v", err)
+	}
+	if got := vecs[0][0]; got != 0 {
+		t.Errorf("vecs[0][0] = %v, want 0", got)
+	}
+	if got := vecs[1][0]; got != 1 {
+		t.Errorf("vecs[1][0] = %v, want 1", got)
+	}
+}
+
+func TestDetect_OpenAIInvalidDimsFallsBackToBundled(t *testing.T) {
+	t.Setenv("CTXPP_EMBED_BACKEND", "openai")
+	t.Setenv("CTXPP_OPENAI_MODEL", "text-embedding-3-small")
+	t.Setenv("CTXPP_OPENAI_DIMS", "not-a-number")
+
+	e, usingExternal := Detect(context.Background())
+	if usingExternal {
+		t.Fatal("Detect() usingExternal = true, want false")
+	}
+	if e.Model() != bundledModel {
+		t.Errorf("Model() = %q, want %q", e.Model(), bundledModel)
+	}
+}
+
 func TestBundledEmbedder_DefaultDims(t *testing.T) {
 	e := NewBundledEmbedder(0) // 0 should default to ollamaDims (1024)
 	if e.Dims() != 1024 {

--- a/internal/embed/openai.go
+++ b/internal/embed/openai.go
@@ -12,6 +12,7 @@ import (
 )
 
 const defaultOpenAIURL = "https://api.openai.com"
+const maxOpenAIErrorBodyBytes = 4096
 
 type openAIEmbedRequest struct {
 	Model string   `json:"model"`
@@ -106,6 +107,13 @@ func (e *OpenAIEmbedder) Ping(ctx context.Context) error {
 }
 
 func (e *OpenAIEmbedder) doEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	if e.model == "" {
+		return nil, fmt.Errorf("openai embed: model is required")
+	}
+	if e.dims <= 0 {
+		return nil, fmt.Errorf("openai embed: dims must be > 0")
+	}
+
 	body, err := json.Marshal(openAIEmbedRequest{Model: e.model, Input: texts})
 	if err != nil {
 		return nil, fmt.Errorf("openai embed: marshal: %w", err)
@@ -137,12 +145,15 @@ func (e *OpenAIEmbedder) doEmbed(ctx context.Context, texts []string) ([][]float
 	if len(result.Data) == 0 {
 		return nil, fmt.Errorf("openai embed: empty response")
 	}
+	if len(result.Data) != len(texts) {
+		return nil, fmt.Errorf("openai embed: got %d embeddings for %d inputs", len(result.Data), len(texts))
+	}
 
-	vecs := make([][]float32, len(result.Data))
-	seen := make([]bool, len(result.Data))
+	vecs := make([][]float32, len(texts))
+	seen := make([]bool, len(texts))
 	for _, item := range result.Data {
-		if item.Index < 0 || item.Index >= len(result.Data) {
-			return nil, fmt.Errorf("openai embed: response index %d out of range for %d embeddings", item.Index, len(result.Data))
+		if item.Index < 0 || item.Index >= len(texts) {
+			return nil, fmt.Errorf("openai embed: response index %d out of range for %d inputs", item.Index, len(texts))
 		}
 		if seen[item.Index] {
 			return nil, fmt.Errorf("openai embed: duplicate response index %d", item.Index)
@@ -161,24 +172,32 @@ func (e *OpenAIEmbedder) doEmbed(ctx context.Context, texts []string) ([][]float
 			return nil, fmt.Errorf("openai embed: missing embedding for response index %d", i)
 		}
 	}
-	if len(vecs) != len(texts) {
-		return nil, fmt.Errorf("openai embed: got %d embeddings for %d inputs", len(vecs), len(texts))
-	}
 	return vecs, nil
 }
 
 func (e *OpenAIEmbedder) httpError(resp *http.Response) error {
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxOpenAIErrorBodyBytes+1))
 	if err != nil {
 		return fmt.Errorf("openai embed: status %d", resp.StatusCode)
 	}
+	truncated := len(body) > maxOpenAIErrorBodyBytes
+	if truncated {
+		body = body[:maxOpenAIErrorBodyBytes]
+	}
 	var apiErr openAIErrorResponse
 	if err := json.Unmarshal(body, &apiErr); err == nil && apiErr.Error != nil && apiErr.Error.Message != "" {
-		return fmt.Errorf("openai embed: status %d: %s", resp.StatusCode, apiErr.Error.Message)
+		msg := apiErr.Error.Message
+		if truncated {
+			msg += "..."
+		}
+		return fmt.Errorf("openai embed: status %d: %s", resp.StatusCode, msg)
 	}
 	msg := strings.TrimSpace(string(body))
 	if msg == "" {
 		return fmt.Errorf("openai embed: status %d", resp.StatusCode)
+	}
+	if truncated {
+		msg += "..."
 	}
 	return fmt.Errorf("openai embed: status %d: %s", resp.StatusCode, msg)
 }

--- a/internal/embed/openai.go
+++ b/internal/embed/openai.go
@@ -1,0 +1,184 @@
+package embed
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const defaultOpenAIURL = "https://api.openai.com"
+
+type openAIEmbedRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+type openAIEmbedResponse struct {
+	Data []openAIEmbedData `json:"data"`
+}
+
+type openAIEmbedData struct {
+	Index     int       `json:"index"`
+	Embedding []float32 `json:"embedding"`
+}
+
+type openAIErrorResponse struct {
+	Error *struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+		Code    any    `json:"code"`
+	} `json:"error"`
+}
+
+// OpenAIEmbedder calls an OpenAI-compatible /v1/embeddings API.
+type OpenAIEmbedder struct {
+	baseURL string
+	model   string
+	apiKey  string
+	dims    int
+	client  *http.Client
+}
+
+// NewOpenAIEmbedder constructs an OpenAI-compatible embedder.
+// If baseURL is empty, https://api.openai.com is used.
+func NewOpenAIEmbedder(baseURL, model, apiKey string, dims int) *OpenAIEmbedder {
+	if baseURL == "" {
+		baseURL = defaultOpenAIURL
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+	return &OpenAIEmbedder{
+		baseURL: baseURL,
+		model:   model,
+		apiKey:  apiKey,
+		dims:    dims,
+		client: &http.Client{
+			Timeout: 120 * time.Second,
+			Transport: &http.Transport{
+				MaxIdleConns:        64,
+				MaxIdleConnsPerHost: 64,
+				IdleConnTimeout:     120 * time.Second,
+				DisableCompression:  true,
+				ForceAttemptHTTP2:   false,
+			},
+		},
+	}
+}
+
+func (e *OpenAIEmbedder) Model() string { return e.model }
+func (e *OpenAIEmbedder) Dims() int     { return e.dims }
+
+func (e *OpenAIEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	vecs, err := e.doEmbed(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(vecs) == 0 {
+		return nil, fmt.Errorf("openai embed: empty response")
+	}
+	return vecs[0], nil
+}
+
+func (e *OpenAIEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	vecs, err := e.doEmbed(ctx, texts)
+	if err != nil {
+		return nil, err
+	}
+	if len(vecs) != len(texts) {
+		return nil, fmt.Errorf("openai embed batch: got %d embeddings for %d inputs", len(vecs), len(texts))
+	}
+	return vecs, nil
+}
+
+func (e *OpenAIEmbedder) Ping(ctx context.Context) error {
+	_, err := e.Embed(ctx, "ping")
+	if err != nil {
+		return fmt.Errorf("openai ping: %w", err)
+	}
+	return nil
+}
+
+func (e *OpenAIEmbedder) doEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	body, err := json.Marshal(openAIEmbedRequest{Model: e.model, Input: texts})
+	if err != nil {
+		return nil, fmt.Errorf("openai embed: marshal: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.baseURL+"/v1/embeddings", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("openai embed: new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if e.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+e.apiKey)
+	}
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("openai embed: http: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, e.httpError(resp)
+	}
+
+	var result openAIEmbedResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("openai embed: decode: %w", err)
+	}
+	if len(result.Data) == 0 {
+		return nil, fmt.Errorf("openai embed: empty response")
+	}
+
+	vecs := make([][]float32, len(result.Data))
+	seen := make([]bool, len(result.Data))
+	for _, item := range result.Data {
+		if item.Index < 0 || item.Index >= len(result.Data) {
+			return nil, fmt.Errorf("openai embed: response index %d out of range for %d embeddings", item.Index, len(result.Data))
+		}
+		if seen[item.Index] {
+			return nil, fmt.Errorf("openai embed: duplicate response index %d", item.Index)
+		}
+		seen[item.Index] = true
+		if len(item.Embedding) == 0 {
+			return nil, fmt.Errorf("openai embed: empty embedding at index %d", item.Index)
+		}
+		if e.dims > 0 && len(item.Embedding) != e.dims {
+			return nil, fmt.Errorf("openai embed: expected %d dims, got %d", e.dims, len(item.Embedding))
+		}
+		vecs[item.Index] = item.Embedding
+	}
+	for i := range vecs {
+		if !seen[i] {
+			return nil, fmt.Errorf("openai embed: missing embedding for response index %d", i)
+		}
+	}
+	if len(vecs) != len(texts) {
+		return nil, fmt.Errorf("openai embed: got %d embeddings for %d inputs", len(vecs), len(texts))
+	}
+	return vecs, nil
+}
+
+func (e *OpenAIEmbedder) httpError(resp *http.Response) error {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("openai embed: status %d", resp.StatusCode)
+	}
+	var apiErr openAIErrorResponse
+	if err := json.Unmarshal(body, &apiErr); err == nil && apiErr.Error != nil && apiErr.Error.Message != "" {
+		return fmt.Errorf("openai embed: status %d: %s", resp.StatusCode, apiErr.Error.Message)
+	}
+	msg := strings.TrimSpace(string(body))
+	if msg == "" {
+		return fmt.Errorf("openai embed: status %d", resp.StatusCode)
+	}
+	return fmt.Errorf("openai embed: status %d: %s", resp.StatusCode, msg)
+}

--- a/internal/embed/openai.go
+++ b/internal/embed/openai.go
@@ -135,7 +135,11 @@ func (e *OpenAIEmbedder) doEmbed(ctx context.Context, texts []string) ([][]float
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, e.httpError(resp)
+		err := e.httpError(resp)
+		if resp.StatusCode >= http.StatusBadRequest && resp.StatusCode < http.StatusInternalServerError && resp.StatusCode != http.StatusTooManyRequests {
+			return nil, NewNonRetryableError(err)
+		}
+		return nil, err
 	}
 
 	var result openAIEmbedResponse


### PR DESCRIPTION
## Summary
- add an `openai` embedder that targets `/v1/embeddings` with batch support, response validation, and optional bearer auth
- wire `CTXPP_EMBED_BACKEND=openai` into backend detection and add coverage for forced config, batch ordering, and unauthenticated local endpoints
- update README and CLI warnings, and include the rollout plan in `docs/OPENAI-EMBEDDINGS-BACKEND-PLAN.md`

## Validation
- `go test ./internal/embed`
- `go test ./...`
- `go vet ./...`